### PR TITLE
Draw a basic icon svg at the default location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Python virtual environment
+.venv/
+venv/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["text-processing", "parsing", "graphics"]
 
 [dependencies]
 skrifa = "0.15.5"
+smol_str = "0.2.1"
 thiserror = "1.0.57"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ categories = ["text-processing", "parsing", "graphics"]
 
 [dependencies]
 skrifa = "0.15.5"
+thiserror = "1.0.57"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,11 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
+kurbo = "0.10.4"
 skrifa = "0.15.5"
 smol_str = "0.2.1"
 thiserror = "1.0.57"
+write-fonts = { version = "0.22.1", default-features = false }
 
 [dev-dependencies]
+pretty_assertions = "1.3.0"

--- a/resources/testdata/README.md
+++ b/resources/testdata/README.md
@@ -1,0 +1,3 @@
+`lan.svg`, `mail.svg`, `man.svg` and `vf[FILL,GRAD,opsz,wght].ttf` are copies of files used for internal testing.
+The svg files were generated using the [hb-draw](https://harfbuzz.github.io/harfbuzz-hb-draw.html) APIs
+orchestrated by a small C++ program.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use skrifa::{outline::DrawError, GlyphId};
 use thiserror::Error;
 
 use crate::iconid::IconIdentifier;
@@ -6,6 +7,12 @@ use crate::iconid::IconIdentifier;
 pub enum DrawSvgError {
     #[error("Unable to determine glyph id for {0:?}: {1}")]
     ResolutionError(IconIdentifier, IconResolutionError),
+    #[error("{0:?} ({1}) has no outline")]
+    NoOutline(IconIdentifier, GlyphId),
+    #[error("{0:?} ({1}) failed to draw: {2}")]
+    DrawError(IconIdentifier, GlyphId, DrawError),
+    #[error("Unable to read {0}: {1}")]
+    ReadError(&'static str, skrifa::raw::ReadError),
 }
 
 #[derive(Debug, Error)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,23 @@
 use thiserror::Error;
 
+use crate::iconid::IconIdentifier;
+
 #[derive(Error, Debug)]
-pub enum DrawSvgError {}
+pub enum DrawSvgError {
+    #[error("Unable to determine glyph id for {0:?}: {1}")]
+    ResolutionError(IconIdentifier, IconResolutionError),
+}
+
+#[derive(Debug, Error)]
+pub enum IconResolutionError {
+    #[error("{0}")]
+    ReadError(skrifa::raw::ReadError),
+    #[error("No character mapping for '{0}'")]
+    UnmappedCharError(char),
+    #[error("The icon name '{0}' resolved to 0 glyph ids")]
+    NoGlyphIds(String),
+    #[error("The icon name '{0}' has no ligature")]
+    NoLigature(String),
+    #[error("The codepoint 0x{0:04x} has no cmap entry")]
+    NoCmapEntry(u32),
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,4 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum DrawSvgError {}

--- a/src/icon2svg.rs
+++ b/src/icon2svg.rs
@@ -1,29 +1,27 @@
 //! Produces svgs of icons in Google-style icon fonts
 
+use crate::{error::DrawSvgError, iconid::IconIdentifier};
 use skrifa::FontRef;
 
-use crate::error::DrawSvgError;
-
-pub fn draw_icon(font: FontRef, codepoint: u32) -> Result<String, DrawSvgError> {
-    todo!()
+pub fn draw_icon(font: &FontRef, identifier: IconIdentifier) -> Result<String, DrawSvgError> {
+    let gid = identifier
+        .resolve(font)
+        .map_err(|e| DrawSvgError::ResolutionError(identifier, e))?;
+    todo!("Draw {gid}")
 }
 
 #[cfg(test)]
 mod tests {
     use skrifa::FontRef;
 
-    use crate::{icon2svg::draw_icon, testdata_bytes, testdata_string};
-
-    static MAIL: u32 = 57688;
-    static LAN: u32 = 60207;
-    static MAN: u32 = 58603;
+    use crate::{icon2svg::draw_icon, iconid, testdata_bytes, testdata_string};
 
     #[test]
     fn draw_mail_icon() {
         let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
         assert_eq!(
             testdata_string("mail.svg"),
-            draw_icon(FontRef::new(&raw_font).unwrap(), MAIL).unwrap()
+            draw_icon(&FontRef::new(&raw_font).unwrap(), iconid::MAIL.clone()).unwrap()
         );
     }
 
@@ -32,7 +30,7 @@ mod tests {
         let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
         assert_eq!(
             testdata_string("lan.svg"),
-            draw_icon(FontRef::new(&raw_font).unwrap(), LAN).unwrap()
+            draw_icon(&FontRef::new(&raw_font).unwrap(), iconid::LAN.clone()).unwrap()
         );
     }
 
@@ -41,7 +39,7 @@ mod tests {
         let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
         assert_eq!(
             testdata_string("man.svg"),
-            draw_icon(FontRef::new(&raw_font).unwrap(), MAN).unwrap()
+            draw_icon(&FontRef::new(&raw_font).unwrap(), iconid::MAN.clone()).unwrap()
         );
     }
 }

--- a/src/icon2svg.rs
+++ b/src/icon2svg.rs
@@ -1,45 +1,160 @@
 //! Produces svgs of icons in Google-style icon fonts
 
 use crate::{error::DrawSvgError, iconid::IconIdentifier};
-use skrifa::FontRef;
+use kurbo::{Affine, BezPath, PathEl, Point};
+use skrifa::{
+    instance::{LocationRef, Size},
+    outline::DrawSettings,
+    raw::TableProvider,
+    FontRef, MetadataProvider,
+};
+use write_fonts::pens::{BezPathPen, TransformPen};
 
-pub fn draw_icon(font: &FontRef, identifier: IconIdentifier) -> Result<String, DrawSvgError> {
-    let gid = identifier
+fn round2(v: f64) -> f64 {
+    (v * 100.0).round() / 100.0
+}
+
+fn push_point(svg: &mut String, prefix: char, p: Point) {
+    svg.push(prefix);
+    svg.push_str(&format!("{},{}", round2(p.x), round2(p.y)));
+}
+
+/// We use this rather than [`BezPath::to_svg`]` so we can exactly match the output of the tool we seek to replace
+fn push_drawing_commands(svg: &mut String, path: &BezPath) {
+    for el in path.elements() {
+        match el {
+            PathEl::MoveTo(p) => push_point(svg, 'M', *p),
+            PathEl::LineTo(p) => push_point(svg, 'L', *p),
+            PathEl::QuadTo(p1, p2) => {
+                push_point(svg, 'Q', *p1);
+                push_point(svg, ' ', *p2);
+            }
+            PathEl::CurveTo(p1, p2, p3) => {
+                push_point(svg, 'C', *p1);
+                push_point(svg, ' ', *p2);
+                push_point(svg, ' ', *p3);
+            }
+            PathEl::ClosePath => svg.push('Z'),
+        }
+    }
+}
+
+pub fn draw_icon(font: &FontRef, options: &DrawOptions<'_>) -> Result<String, DrawSvgError> {
+    let upem = font
+        .head()
+        .map_err(|e| DrawSvgError::ReadError("cmap", e))?
+        .units_per_em();
+    let gid = options
+        .identifier
         .resolve(font)
-        .map_err(|e| DrawSvgError::ResolutionError(identifier, e))?;
-    todo!("Draw {gid}")
+        .map_err(|e| DrawSvgError::ResolutionError(options.identifier.clone(), e))?;
+
+    let glyph = font
+        .outline_glyphs()
+        .get(gid)
+        .ok_or(DrawSvgError::NoOutline(options.identifier.clone(), gid))?;
+
+    // Draw the glyph. Fonts are Y-up, svg Y-down so flip-y.
+    let mut path_pen = BezPathPen::new();
+    let mut transform_pen = TransformPen::new(&mut path_pen, Affine::FLIP_Y);
+
+    glyph
+        .draw(
+            DrawSettings::unhinted(Size::unscaled(), options.location),
+            &mut transform_pen,
+        )
+        .map_err(|e| DrawSvgError::DrawError(options.identifier.clone(), gid, e))?;
+
+    let upem_str = format!("{upem}");
+    let width_height = format!("{}", options.width_height);
+    let mut svg = String::with_capacity(1024);
+    // svg preamble
+    // This viewBox matches existing code we are moving to Rust
+    svg.push_str("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 -");
+    svg.push_str(&upem_str);
+    svg.push(' ');
+    svg.push_str(&upem_str);
+    svg.push(' ');
+    svg.push_str(upem_str.as_str());
+    svg.push_str("\" height=\"");
+    svg.push_str(&width_height);
+    svg.push_str("\" width=\"");
+    svg.push_str(&width_height);
+    svg.push_str("\">");
+
+    // the actual path
+    svg.push_str("<path d=\"");
+    push_drawing_commands(&mut svg, &path_pen.into_inner());
+    svg.push_str("\">");
+
+    // svg ending
+    svg.push_str("</svg>");
+
+    Ok(svg)
+}
+
+pub struct DrawOptions<'a> {
+    identifier: IconIdentifier,
+    width_height: f32,
+    location: LocationRef<'a>,
+}
+
+impl<'a> DrawOptions<'a> {
+    pub fn new(
+        identifier: IconIdentifier,
+        width_height: f32,
+        location: LocationRef<'a>,
+    ) -> DrawOptions<'a> {
+        DrawOptions {
+            identifier,
+            width_height,
+            location,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use skrifa::FontRef;
+    use crate::{
+        icon2svg::draw_icon,
+        iconid::{self, IconIdentifier},
+        testdata_bytes, testdata_string,
+    };
+    use pretty_assertions::assert_eq;
+    use skrifa::{FontRef, MetadataProvider};
 
-    use crate::{icon2svg::draw_icon, iconid, testdata_bytes, testdata_string};
+    use super::DrawOptions;
+
+    // Matches tests in code to be replaced
+    fn assert_draw_icon(expected_file: &str, identifier: IconIdentifier) {
+        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
+        let font = FontRef::new(&raw_font).unwrap();
+        let loc = font.axes().location(&[
+            ("wght", 400.0),
+            ("opsz", 24.0),
+            ("GRAD", 0.0),
+            ("FILL", 1.0),
+        ]);
+        let options = DrawOptions::new(identifier, 24.0, (&loc).into());
+
+        assert_eq!(
+            testdata_string(expected_file),
+            draw_icon(&font, &options).unwrap()
+        );
+    }
 
     #[test]
     fn draw_mail_icon() {
-        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
-        assert_eq!(
-            testdata_string("mail.svg"),
-            draw_icon(&FontRef::new(&raw_font).unwrap(), iconid::MAIL.clone()).unwrap()
-        );
+        assert_draw_icon("mail.svg", iconid::MAIL.clone());
     }
 
     #[test]
     fn draw_lan_icon() {
-        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
-        assert_eq!(
-            testdata_string("lan.svg"),
-            draw_icon(&FontRef::new(&raw_font).unwrap(), iconid::LAN.clone()).unwrap()
-        );
+        assert_draw_icon("lan.svg", iconid::LAN.clone());
     }
 
     #[test]
     fn draw_man_icon() {
-        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
-        assert_eq!(
-            testdata_string("man.svg"),
-            draw_icon(&FontRef::new(&raw_font).unwrap(), iconid::MAN.clone()).unwrap()
-        );
+        assert_draw_icon("man.svg", iconid::MAN.clone());
     }
 }

--- a/src/icon2svg.rs
+++ b/src/icon2svg.rs
@@ -8,6 +8,7 @@ use skrifa::{
     raw::TableProvider,
     FontRef, MetadataProvider,
 };
+use std::fmt::Write;
 use write_fonts::pens::{BezPathPen, TransformPen};
 
 fn round2(v: f64) -> f64 {
@@ -16,7 +17,7 @@ fn round2(v: f64) -> f64 {
 
 fn push_point(svg: &mut String, prefix: char, p: Point) {
     svg.push(prefix);
-    svg.push_str(&format!("{},{}", round2(p.x), round2(p.y)));
+    write!(svg, "{},{}", round2(p.x), round2(p.y)).expect("We can't write into a String?!");
 }
 
 /// We use this rather than [`BezPath::to_svg`]` so we can exactly match the output of the tool we seek to replace
@@ -42,7 +43,7 @@ fn push_drawing_commands(svg: &mut String, path: &BezPath) {
 pub fn draw_icon(font: &FontRef, options: &DrawOptions<'_>) -> Result<String, DrawSvgError> {
     let upem = font
         .head()
-        .map_err(|e| DrawSvgError::ReadError("cmap", e))?
+        .map_err(|e| DrawSvgError::ReadError("head", e))?
         .units_per_em();
     let gid = options
         .identifier
@@ -65,8 +66,8 @@ pub fn draw_icon(font: &FontRef, options: &DrawOptions<'_>) -> Result<String, Dr
         )
         .map_err(|e| DrawSvgError::DrawError(options.identifier.clone(), gid, e))?;
 
-    let upem_str = format!("{upem}");
-    let width_height = format!("{}", options.width_height);
+    let upem_str = upem.to_string();
+    let width_height = options.width_height.to_string();
     let mut svg = String::with_capacity(1024);
     // svg preamble
     // This viewBox matches existing code we are moving to Rust

--- a/src/icon2svg.rs
+++ b/src/icon2svg.rs
@@ -1,0 +1,47 @@
+//! Produces svgs of icons in Google-style icon fonts
+
+use skrifa::FontRef;
+
+use crate::error::DrawSvgError;
+
+pub fn draw_icon(font: FontRef, codepoint: u32) -> Result<String, DrawSvgError> {
+    todo!()
+}
+
+#[cfg(test)]
+mod tests {
+    use skrifa::FontRef;
+
+    use crate::{icon2svg::draw_icon, testdata_bytes, testdata_string};
+
+    static MAIL: u32 = 57688;
+    static LAN: u32 = 60207;
+    static MAN: u32 = 58603;
+
+    #[test]
+    fn draw_mail_icon() {
+        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
+        assert_eq!(
+            testdata_string("mail.svg"),
+            draw_icon(FontRef::new(&raw_font).unwrap(), MAIL).unwrap()
+        );
+    }
+
+    #[test]
+    fn draw_lan_icon() {
+        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
+        assert_eq!(
+            testdata_string("lan.svg"),
+            draw_icon(FontRef::new(&raw_font).unwrap(), LAN).unwrap()
+        );
+    }
+
+    #[test]
+    fn draw_man_icon() {
+        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
+        assert_eq!(
+            testdata_string("man.svg"),
+            draw_icon(FontRef::new(&raw_font).unwrap(), MAN).unwrap()
+        );
+    }
+}

--- a/src/icon2svg.rs
+++ b/src/icon2svg.rs
@@ -144,16 +144,19 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // until matching svgs is fixed
     fn draw_mail_icon() {
         assert_draw_icon("mail.svg", iconid::MAIL.clone());
     }
 
     #[test]
+    #[ignore] // until matching svgs is fixed
     fn draw_lan_icon() {
         assert_draw_icon("lan.svg", iconid::LAN.clone());
     }
 
     #[test]
+    #[ignore] // until matching svgs is fixed
     fn draw_man_icon() {
         assert_draw_icon("man.svg", iconid::MAN.clone());
     }

--- a/src/iconid.rs
+++ b/src/iconid.rs
@@ -26,7 +26,7 @@ impl IconIdentifier {
                 .cmap()
                 .map_err(IconResolutionError::ReadError)?
                 .map_codepoint(*cp)
-                .ok_or_else(|| IconResolutionError::NoCmapEntry(*cp)),
+                .ok_or(IconResolutionError::NoCmapEntry(*cp)),
             IconIdentifier::Name(name) => resolve_icon_ligature(font, name.as_str()),
         }
     }

--- a/src/iconid.rs
+++ b/src/iconid.rs
@@ -1,0 +1,157 @@
+//! Identification of icons and resolution of glyph ids. Assumes Google style icon font input.
+use skrifa::{
+    charmap::Charmap,
+    raw::{
+        tables::gsub::{ExtensionSubtable, LigatureSubstFormat1, SubstitutionLookup},
+        FontRef, TableProvider,
+    },
+    GlyphId,
+};
+use smol_str::SmolStr;
+
+use crate::error::IconResolutionError;
+
+#[derive(Clone, Debug)]
+pub enum IconIdentifier {
+    GlyphId(GlyphId),
+    Codepoint(u32),
+    Name(SmolStr),
+}
+
+impl IconIdentifier {
+    pub fn resolve(&self, font: &FontRef) -> Result<GlyphId, IconResolutionError> {
+        match self {
+            IconIdentifier::GlyphId(gid) => Ok(*gid),
+            IconIdentifier::Codepoint(cp) => font
+                .cmap()
+                .map_err(IconResolutionError::ReadError)?
+                .map_codepoint(*cp)
+                .ok_or_else(|| IconResolutionError::NoCmapEntry(*cp)),
+            IconIdentifier::Name(name) => resolve_icon_ligature(font, name.as_str()),
+        }
+    }
+}
+
+fn resolve_ligature(
+    liga: &LigatureSubstFormat1<'_>,
+    text: &str,
+    gids: &[GlyphId],
+) -> Result<Option<GlyphId>, IconResolutionError> {
+    let Some(first) = gids.first() else {
+        return Err(IconResolutionError::NoGlyphIds(text.to_string()));
+    };
+    let coverage = liga.coverage().map_err(IconResolutionError::ReadError)?;
+    let Some(set_index) = coverage.get(*first) else {
+        return Ok(None);
+    };
+    let set = liga
+        .ligature_sets()
+        .get(set_index as usize)
+        .map_err(IconResolutionError::ReadError)?;
+    // Seek a ligature that matches glyphs 2..N of name
+    // We don't care about speed
+    let gids = &gids[1..];
+    for liga in set.ligatures().iter() {
+        let liga = liga.map_err(IconResolutionError::ReadError)?;
+        if liga.component_count() as usize != gids.len() + 1 {
+            continue;
+        }
+        if gids
+            .iter()
+            .zip(liga.component_glyph_ids())
+            .all(|(gid, component)| *gid == component.get())
+        {
+            return Ok(Some(liga.ligature_glyph())); // We found it!
+        }
+    }
+    Ok(None)
+}
+
+pub fn resolve_icon_ligature(font: &FontRef, name: &str) -> Result<GlyphId, IconResolutionError> {
+    let charmap = Charmap::new(font);
+    let gids = name
+        .chars()
+        .map(|c| {
+            charmap
+                .map(c)
+                .ok_or(IconResolutionError::UnmappedCharError(c))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Step 1: try to find a ligature that starts with our first gid
+    let gsub = font.gsub().map_err(IconResolutionError::ReadError)?;
+    let lookups = gsub.lookup_list().map_err(IconResolutionError::ReadError)?;
+    for lookup in lookups.lookups().iter() {
+        let lookup = lookup.map_err(IconResolutionError::ReadError)?;
+        match lookup {
+            SubstitutionLookup::Ligature(table) => {
+                for liga in table.subtables().iter() {
+                    let liga = liga.map_err(IconResolutionError::ReadError)?;
+                    if let Some(gid) = resolve_ligature(&liga, name, &gids)? {
+                        return Ok(gid);
+                    }
+                }
+            }
+            SubstitutionLookup::Extension(table) => {
+                for lookup in table.subtables().iter() {
+                    let ExtensionSubtable::Ligature(table) =
+                        lookup.map_err(IconResolutionError::ReadError)?
+                    else {
+                        continue;
+                    };
+                    let table = table.extension().map_err(IconResolutionError::ReadError)?;
+
+                    if let Some(gid) = resolve_ligature(&table, name, &gids)? {
+                        return Ok(gid);
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+    Err(IconResolutionError::NoLigature(name.to_string()))
+}
+
+#[cfg(test)]
+pub static MAIL: IconIdentifier = IconIdentifier::Codepoint(57688);
+#[cfg(test)]
+pub static LAN: IconIdentifier = IconIdentifier::Name(SmolStr::new_static("lan"));
+#[cfg(test)]
+pub static MAN: IconIdentifier = IconIdentifier::GlyphId(GlyphId::new(5));
+
+#[cfg(test)]
+mod tests {
+    use skrifa::{FontRef, GlyphId};
+
+    use crate::{
+        iconid::{LAN, MAIL, MAN},
+        testdata_bytes,
+    };
+
+    #[test]
+    fn resolve_mail_icon() {
+        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
+        assert_eq!(
+            GlyphId::new(1),
+            MAIL.resolve(&FontRef::new(&raw_font).unwrap()).unwrap()
+        );
+    }
+
+    #[test]
+    fn resolve_lan_icon() {
+        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
+        assert_eq!(
+            GlyphId::new(3),
+            LAN.resolve(&FontRef::new(&raw_font).unwrap()).unwrap()
+        );
+    }
+
+    #[test]
+    fn resolve_man_icon() {
+        let raw_font = testdata_bytes("vf[FILL,GRAD,opsz,wght].ttf");
+        assert_eq!(
+            GlyphId::new(5),
+            MAN.resolve(&FontRef::new(&raw_font).unwrap()).unwrap()
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,24 @@
+mod error;
+mod icon2svg;
 
+#[cfg(test)]
+pub(crate) fn testdata_dir() -> std::path::PathBuf {
+    use std::{path::PathBuf, str::FromStr};
+    PathBuf::from_str("resources/testdata").unwrap()
+}
+
+#[cfg(test)]
+pub(crate) fn testdata_string(path: &str) -> String {
+    use std::fs;
+
+    let path = testdata_dir().join(path);
+    fs::read_to_string(&path).unwrap_or_else(|e| panic!("Unable to read {path:?}: {e}"))
+}
+
+#[cfg(test)]
+pub(crate) fn testdata_bytes(path: &str) -> Vec<u8> {
+    use std::fs;
+
+    let path = testdata_dir().join(path);
+    fs::read(&path).unwrap_or_else(|e| panic!("Unable to read {path:?}: {e}"))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-mod error;
-mod icon2svg;
+pub mod error;
+pub mod icon2svg;
 pub mod iconid;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod error;
 mod icon2svg;
+pub mod iconid;
 
 #[cfg(test)]
 pub(crate) fn testdata_dir() -> std::path::PathBuf {


### PR DESCRIPTION
Produce svgs, albeit not the ones we ultimately want. Ex https://codepen.io/rs42/pen/ZEZYwem. This is for two reasons:

1. because hb-draw (source of the expected value) applies substitutions while Skrifa does not.
1. because hb-draw and skrifa handle a pointstream that starts with an off-curve differently
   * Skrifa matches FreeType and takes the last point as the start
   * hb-draw walks forward to find the first oncurve then continues on and uses the buffered off-curve at the end
      * conceptually walks all the points starting with the first oncurve it finds, wrapping if that wasn't the first

Three tests are marked ignore because of ^.