### PR TITLE
Confirm hb-draw style off-curve first resolution helps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,12 @@ categories = ["text-processing", "parsing", "graphics"]
 
 [dependencies]
 kurbo = "0.10.4"
-skrifa = "0.15.5"
+# TEMPORARY, to test https://github.com/googlefonts/fontations/pull/818
+skrifa = { git = "https://github.com/googlefonts/fontations.git" }
+write-fonts = { version = "0.23.0", default-features = false }
+
 smol_str = "0.2.1"
 thiserror = "1.0.57"
-write-fonts = { version = "0.22.1", default-features = false }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [dependencies]
 kurbo = "0.10.4"
 # TEMPORARY, to test https://github.com/googlefonts/fontations/pull/818
-skrifa = { git = "https://github.com/googlefonts/fontations.git" }
-write-fonts = { version = "0.23.0", default-features = false }
+skrifa = { git = "https://github.com/googlefonts/fontations.git", branch = "the_last_first" }
+write-fonts = { git = "https://github.com/googlefonts/fontations.git", default-features = false, branch = "the_last_first" }
 
 smol_str = "0.2.1"
 thiserror = "1.0.57"


### PR DESCRIPTION
https://github.com/googlefonts/fontations/pull/818 appears to make 2/3 of our svg paths match. The last one is very close, for some reason the legacy code isn't putting in the line on the final Z:

```
M...Q513,-720 480,-720Z
M...Q513,-720 480,-720L480,-720Z
                      ^ a final line, but only for man.svg!
```

EDIT: ^ is fixed, all examples now match. Ty @anthrotype for pointing out the key code in hb-draw.